### PR TITLE
Draft the "Patterns of collaboration" section

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,6 +10,7 @@ book:
   repo-actions: [edit, issue]
   chapters:
     - index.qmd
+    - collaboration/index.qmd
     - part: reviewer/index.qmd
       chapters:
       - reviewer/purpose.qmd

--- a/collaboration/index.qmd
+++ b/collaboration/index.qmd
@@ -30,7 +30,7 @@ ggplot2, dtplyr, and dbplyr have a number of core contributors that aren't emplo
 An understudy typically follows a project from afar, generally submitting smaller PRs or doing superficial code review with a focus on API design, unit tests, and documentation.
 This allows the understudy to stay up to date with a project they may potentially take over in the future.
 
-When an understudy submits a PR, review is typically swift, in-depth, and comes from a core maintainer.
+When an understudy submits a PR, review is typically swift, in-depth, and comes from a core maintainer as long as that maintainer is actively working on that package.
 Understudy PRs are often smaller in scope, and can occasionally require multiple rounds of review if they aren't intimately familiar with the specifics of the package they are working on.
 If both the understudy and reviewer are Posit employees, discussing the review live (i.e. over Zoom) is often very beneficial for the understudy's overall understanding of the package.
 

--- a/collaboration/index.qmd
+++ b/collaboration/index.qmd
@@ -3,7 +3,7 @@
 Within the tidyteam group, the way we collaborate with colleagues and external contributors is highly dependent on the context of who is working on a particular package, how closely the contributors are working together, and how often that package is updated.
 A large amount of the advice in this guide is independent of any specific collaboration context, but some aspects, such as the expected turnaround time of a code review, and the level of detail that is expected from a review, is closely tied to it.
 
-It is important to keep in mind that package development at Posit is probably a little different from software development at other companies.
+It is important to keep in mind that package development within the tidyteam group is probably a little different from software development at other companies.
 Packages often lie dormant for awhile as the core maintainer works on other projects, which means that sometimes PRs take longer to get reviewed than expected.
 This is typically expected when working with other tidyteam colleagues, but can be surprising to a community member that is submitting their first PR.
 If you don't see any recent activity on the `main` branch of a package, it is likely that the package is dormant, but rest assured that we will eventually get to your PR.

--- a/collaboration/index.qmd
+++ b/collaboration/index.qmd
@@ -1,0 +1,54 @@
+# Patterns of collaboration {#sec-patterns-of-collaboration .unnumbered}
+
+Within the tidyteam group, the way we collaborate with colleagues and external contributors is highly dependent on the context of who is working on a particular package, how closely the contributors are working together, and how often that package is updated.
+A large amount of the advice in this guide is independent of any specific collaboration context, but some aspects, such as the expected turnaround time of a code review, and the level of detail that is expected from a review, is closely tied to it.
+
+It is important to keep in mind that package development at Posit is probably a little different from software development at other companies.
+Packages often lie dormant for awhile as the core maintainer works on other projects, which means that sometimes PRs take longer to get reviewed than expected.
+This is typically expected when working with other tidyteam colleagues, but can be surprising to a community member that is submitting their first PR.
+If you don't see any recent activity on the `main` branch of a package, it is likely that the package is dormant, but rest assured that we will eventually get to your PR.
+
+In the following sections, we discuss three patterns of collaboration that we use in the tidyteam group which help us to be explicit about our expectations.
+These patterns act as a guide and reference, rather than something that is set in stone.
+Developers should feel free to modify the patterns as needed - the most important thing is that you are *communicating* these expectations to your team and to your larger user base.
+
+In other sections of this guide, we reference these three patterns when making a distinction between them is useful.
+
+### Close-knit collaboration {#sec-close-knit-collaboration}
+
+In a close-knit collaboration, the PR author and PR reviewer are both heavy contributors to a particular package.
+It is common for them to be in close contact with each other (i.e. over Slack), and they often coordinate with each other to avoid overlapping each other's work.
+
+With this pattern, reviews are typically swift to avoid blocking one another, which means it is particularly important to focus on writing [small](#sec-small) PRs.
+Reviews are also in-depth by default, since both developers have significant amount of experience with the package, and should communicate with each other if a superficial review is good enough.
+
+Note that close-knit collaborators aren't restricted to Posit employees.
+ggplot2, dtplyr, and dbplyr have a number of core contributors that aren't employed by Posit that would be considered under this pattern.
+
+### The understudy {#sec-the-understudy}
+
+An understudy typically follows a project from afar, generally submitting smaller PRs or doing superficial code review with a focus on API design, unit tests, and documentation.
+This allows the understudy to stay up to date with a project they may potentially take over in the future.
+
+When an understudy submits a PR, review is typically swift, in-depth, and comes from a core maintainer.
+Understudy PRs are often smaller in scope, and can occasionally require multiple rounds of review if they aren't intimately familiar with the specifics of the package they are working on.
+If both the understudy and reviewer are Posit employees, discussing the review live (i.e. over Zoom) is often very beneficial for the understudy's overall understanding of the package.
+
+When an understudy reviews a PR, review is expected to be swift, and the PR assigned to the understudy for review should not require an in-depth knowledge of the package.
+If the understudy isn't available to review, it is fine to merge the PR without waiting for a review, especially if it is blocking some other work.
+
+An understudy may take the form of an intern at Posit, a motivated community member, or another tidyteam member.
+
+### External contributions {#sec-external-contributions}
+
+An external contribution is a PR authored by someone who isn't a regular contributor to a package.
+This may be a one-off PR from a community member, but is often another tidyteam member that notices a small bug or feature that is missing from a package they don't typically work on.
+For example, I am not a regular contributor to usethis, but noticed a small non-critical bug and [sent in a PR for it](https://github.com/r-lib/usethis/pull/1786).
+
+When an external contributor authors a PR, they should not expect an immediate review.
+If the package is in a dormant state, it is possible that the PR won't be looked at for weeks at a time.
+When the reviewer eventually does look at the PR, if they have comments that need to be addressed, then they should feel free to make a judgement call on whether or not to request that the PR author make the changes, or to just [finish off the PR themselves](#sec-finishing-off-a-pr).
+No matter what the reviewer decides, they should thank the author for their contributions.
+
+If the external contributor is a Posit employee and the PR fixes a bug or adds a feature that is a blocker for one of their projects, then the PR author should coordinate with the reviewer to ensure that the PR can be reviewed and merged in a timely manner.
+If the PR is a blocker, it is important for the package maintainer to respect the deadlines of the PR author, even if they aren't currently working on the package.

--- a/collaboration/index.qmd
+++ b/collaboration/index.qmd
@@ -47,7 +47,7 @@ For example, I am not a regular contributor to usethis, but noticed a small non-
 
 When an external contributor authors a PR, they should not expect an immediate review.
 If the package is in a dormant state, it is possible that the PR won't be looked at for weeks or even months at a time.
-When the reviewer eventually does look at the PR, if they have comments that need to be addressed, then they should feel free to make a judgement call on whether or not to request that the PR author make the changes, or to just [finish off the PR themselves](#sec-finishing-off-a-pr).
+When the reviewer eventually does look at the PR, if they have comments that need to be addressed, then they should feel free to make a judgement call on whether or not to request that the PR author make the changes, or to just [finish off the PR themselves](#sec-finishing-off-an-external-contribution).
 No matter what the reviewer decides, they should thank the author for their contributions.
 
 If the external contributor is a Posit employee and the PR fixes a bug or adds a feature that is a blocker for one of their projects, then the PR author should coordinate with the reviewer to ensure that the PR can be reviewed and merged in a timely manner.

--- a/collaboration/index.qmd
+++ b/collaboration/index.qmd
@@ -37,7 +37,7 @@ If both the understudy and reviewer are Posit employees, discussing the review l
 When an understudy reviews a PR, review is expected to be swift, and the PR assigned to the understudy for review should not require an in-depth knowledge of the package.
 If the understudy isn't available to review, it is fine to merge the PR without waiting for a review, especially if it is blocking some other work.
 
-An understudy may take the form of an intern at Posit, a motivated community member, or another tidyteam member.
+An understudy may be an intern at Posit, a motivated community member, or another tidyteam member.
 
 ### External contributions {#sec-external-contributions}
 
@@ -46,7 +46,7 @@ This may be a one-off PR from a community member, but is often another tidyteam 
 For example, I am not a regular contributor to usethis, but noticed a small non-critical bug and [sent in a PR for it](https://github.com/r-lib/usethis/pull/1786).
 
 When an external contributor authors a PR, they should not expect an immediate review.
-If the package is in a dormant state, it is possible that the PR won't be looked at for weeks at a time.
+If the package is in a dormant state, it is possible that the PR won't be looked at for weeks or even months at a time.
 When the reviewer eventually does look at the PR, if they have comments that need to be addressed, then they should feel free to make a judgement call on whether or not to request that the PR author make the changes, or to just [finish off the PR themselves](#sec-finishing-off-a-pr).
 No matter what the reviewer decides, they should thank the author for their contributions.
 

--- a/index.qmd
+++ b/index.qmd
@@ -4,22 +4,14 @@ A code review is a process where someone other than the author of a piece of cod
 At Posit, we use code review to maintain the quality of our code and products.
 
 This guide serves as a reference for different aspects of the code review process.
-It is intended to be used as a way to get new developers up to speed on how we do code review at Posit, and to serve as a linkable resource when there are questions about aspects of the code review process.
+It is written with the *tidyteam* in mind, which make up the combination of the [tidyverse](https://www.tidyverse.org/), [tidymodels](https://www.tidymodels.org/), and [mlops](https://vetiver.rstudio.com/) groups, but is generally applicable to a large amount of the software development we do at Posit.
+The guide is intended to be used as a way to get new developers up to speed on how we perform code review, and to serve as a linkable resource when there are questions about aspects of the code review process.
 
-The guide is broken into two sections:
-
--   How to review a pull request
--   How to author a pull request
-
-At Posit, we mostly use [GitHub](https://github.com/) as the hosting platform for our code, so many details of this guide might refer to aspects specific to doing pull requests using GitHub's tooling.
+We mostly use [GitHub](https://github.com/) as the hosting platform for our code, so many details of this guide might refer to aspects specific to doing pull requests using GitHub's tooling.
 Additionally, we have a number of R packages that facilitate working on R packages and authoring/reviewing pull requests.
 In particular, you will see references to [`devtools`](https://devtools.r-lib.org/) and [`usethis`](https://usethis.r-lib.org/) throughout this guide.
 
-## Terminology
-
--   **PR** - Shortened notation for a *pull request*.
--   **Internal PR** - A pull request that is both authored and reviewed by Posit employees.
--   **External PR** - A pull request that is authored by a community member, and reviewed by a Posit employee.
+We will use the abbreviation PR to mean a *pull request*, typically on GitHub.
 
 ## Acknowledgements
 

--- a/reviewer/comments.qmd
+++ b/reviewer/comments.qmd
@@ -67,12 +67,12 @@ Here are some examples:
 This makes review intent explicit and helps authors prioritize the importance of various comments.
 It also helps avoid misunderstandings; for example, without comment labels, authors may interpret all comments as mandatory, even if some comments are merely intended to be informational or optional.
 
-## Finishing off an external PR {#sec-finishing-off-a-pr}
+## Finishing off an external contribution {#sec-finishing-off-an-external-contribution}
 
-Sometimes when we receive *external PRs*, we decide that, rather than leaving comments for the external contributor, it is more efficient for us as the reviewer (and usually package maintainer) to just finish off the PR and merge it for them.
+Sometimes when we receive [external contributions](#sec-external-contributions), we decide that rather than leaving comments for the external contributor, it is more efficient for us as the reviewer (and usually package maintainer) to just finish off the PR and merge it for them.
 This typically happens when we come back to work on a package after letting it lie dormant for a few months, and we find that we have a few PRs from external contributors.
 Sometimes these PRs can sit for awhile while no one is actively working on the package, and it might not make much sense to leave comments for the PR author weeks after they sent the PR in.
 Using `usethis::pr_fetch()` and `usethis::pr_push()`, you can instead just take over the PR, fix any minor issues, and merge it in.
 Make sure that if you do this, you also thank the contributor for their contributions!
 
-It is also appropriate to suggest to a PR author that you'd like take over the PR if you have already gone through 1-2 rounds of PR review and there are still a few minor edits that need to be made before the PR is ready to be merged.
+It is also appropriate to inform a PR author that you'll finish off a PR if you have already gone through 1-2 rounds of PR review and there are still a few minor edits that need to be made before the PR is ready to be merged.

--- a/reviewer/comments.qmd
+++ b/reviewer/comments.qmd
@@ -67,7 +67,7 @@ Here are some examples:
 This makes review intent explicit and helps authors prioritize the importance of various comments.
 It also helps avoid misunderstandings; for example, without comment labels, authors may interpret all comments as mandatory, even if some comments are merely intended to be informational or optional.
 
-## Finishing off an external PR
+## Finishing off an external PR {#sec-finishing-off-a-pr}
 
 Sometimes when we receive *external PRs*, we decide that, rather than leaving comments for the external contributor, it is more efficient for us as the reviewer (and usually package maintainer) to just finish off the PR and merge it for them.
 This typically happens when we come back to work on a package after letting it lie dormant for a few months, and we find that we have a few PRs from external contributors.

--- a/reviewer/navigate.qmd
+++ b/reviewer/navigate.qmd
@@ -14,13 +14,13 @@ Here are three steps to tackle most code reviews:
 Before looking at any code, you should familiarize yourself with the GitHub issue / bug report that the PR is resolving, and read over the PR [description](#sec-descriptions) to better orient yourself.
 Does this change even make sense?
 You can save everyone time if the answer is *no* by stopping the review there and responding with an explanation of why the change isn't necessary.
-Ideally, for *internal PRs*, you will have discussed this ahead of time to avoid the author putting in unnecessary work (and feeling bad if their work is rejected).
-For *external PRs*, occasionally you do have to reject PRs from community members if they don't fit the overall [design](#sec-design) of the codebase.
+Ideally, when performing [close-knit collaboration](#sec-close-knit-collaboration), you will have discussed this ahead of time to avoid the author putting in unnecessary work (and feeling bad if their work is rejected).
+For [external contributions](#sec-external-contributions), occasionally you do have to reject PRs if they don't fit the overall [design](#sec-design) of the codebase.
 You should do this nicely, thanking them for their contribution, and requesting that next time they open an issue first and ask if we'd accept a PR for that issue, which would have saved them time if we had an opportunity to preemptively say no.
 
 For example, you might say: "Looks like you put some good work into this, thanks! However, we're actually going in the direction of removing the `foo()` helper that you're modifying here, and so we don't want to make any new modifications to it right now. In the future, it is best if you open an issue first to highlight the bug or feature and ask if we'd accept a pull request for it at this time."
 
-If you get more than a few PRs that represent changes you don't want to make, you should consider re-working your team's development process or the posted process for external contributors so that there is more communication before PRs are written.
+If you get more than a few PRs that represent changes you don't want to make, you should consider re-working your team's development process or the posted process for [external contributors](#sec-external-contributions) so that there is more communication before PRs are written.
 It's better to tell people "no" before they've done a ton of work that now has to be thrown away or drastically re-written.
 
 ## Examine the main parts of the PR

--- a/reviewer/speed.qmd
+++ b/reviewer/speed.qmd
@@ -5,55 +5,46 @@
 The speed of an individual developer is important, but the speed at which a *team* of developers can produce high quality code is even more important.
 When code reviews are slow, several things happen:
 
--   **Developers start to protest the code review process.** If a reviewer only responds every few days, but requests major changes to the PR each time, that can be frustrating and difficult for developers.
-    If the reviewer requests the *same* substantial changes (changes which really do improve code health), but responds *quickly* every time the developer makes an update, the frustration tends to disappear.
+-   **Developers start to protest the code review process.** If a reviewer only responds every few days, but requests major changes to the PR each time, that can be frustrating and difficult for the author.
+    If the reviewer requests the *same* substantial changes (changes which really do improve code health), but responds *quickly* every time the author makes an update, the frustration tends to disappear.
     **Most complaints about the code review process are actually resolved by making the process faster.**
 
 -   **The velocity of the team as a whole is decreased.** Yes, the individual who doesn't respond quickly to the review gets other work done.
     However, new features and bug fixes for the rest of the team are delayed by days, weeks, or months as each PR waits for review.
 
--   **Code health can be impacted.** When reviews are slow, developers are actually incentivized to submit *fewer* PRs and to make each one *larger*.
+-   **Code health can be impacted.** When reviews are slow, authors are actually incentivized to submit *fewer* PRs and to make each one *larger*.
     If you think that it is going to take days to get a single small change reviewed, you are going to be pressured to include *one more thing* in your PR just to avoid another multi-day review process.
-    To ensure that each PR only improves the health of the codebase, code review must be fast enough that developers don't feel hamstrung by it.
+    To ensure that each PR only improves the health of the codebase, code review must be fast enough that authors don't feel hamstrung by it.
 
-## Average turnaround time {#sec-turnaround}
+## What do we mean by "fast"?
 
-If you are not in the middle of a focused task, you should do a code review shortly after it comes in.
+Rather than suggesting average turnaround times for a PR review (such as 2-4 hours), we feel that it is more useful to categorize PRs under different [patterns of collaboration](#sec-patterns-of-collaboration).
+This recognizes the fact that each PR comes with its own context - a time sensitive bug fix that blocks another colleague is going to be reviewed and merged faster than a small typo in a dormant package that isn't actively being worked on.
 
-On average, an internal PR should be reviewed within 2-4 work hours of PR submission.
-It should take at most two business days to respond to a review request.
+The most important thing is for the author and reviewer to have similar expectations around the amount of time a PR review may take.
+If there is confusion around this, the author and reviewer should discuss this with each other, especially if they are both Posit employees, to ensure that they are on the same page about which [pattern](#sec-patterns-of-collaboration) their style of collaboration falls under (keeping in mind that the patterns can be modified as needed).
 
-Following these guidelines means that a typical PR should get multiple rounds of review (if needed) within a single day, although most PRs should only require a single round of review, typically an [approval with comments](#sec-approve-with-comments).
-
-If this seems difficult, it is worth reviewing your PR process.
-If you have so many PRs to review that you can't get to your own work, then you might need to distribute the reviews to your team more.
+If you are feeling overwhelmed by the amount of PRs that you are in charge of, it is worth reviewing your PR process.
+If you have so many PRs to review that you can't get to your own work, then you might need to distribute the reviews across your team more evenly.
 Not speaking up when you are overwhelmed by PRs can in turn slow down an entire team!
 
 ## Speed vs Interruption {#sec-interruption}
 
 There is one time where the consideration of personal velocity trumps team velocity.
 **If you are in the middle of a focused task, such as writing code, don't interrupt yourself to do a code review.** Research has shown that it can take a long time for a developer to get back into a smooth flow of development after being interrupted.
-So interrupting yourself while coding is actually *more* expensive to the team than making another developer wait a bit for a code review.
+So interrupting yourself while coding is actually *more* expensive to the team than making a PR author wait a bit for a code review.
 If you want to read more about this, Paul Graham's post on [Maker vs Manager](http://www.paulgraham.com/makersschedule.html) is very good.
 
 Instead, wait for a break point in your work before you respond to a request for review.
 This could be when your current coding task is completed, after lunch, returning from a meeting, coming back from the breakroom, etc.
-Most "deep work" sessions last around 2-3 hours, so batching your code reviews and handling multiple of them at once after a focused session is generally a good idea and is in line with the 2-4 hour [average turnaround time](#sec-turnaround) mentioned above.
-
-## Fast rounds {#sec-responses}
-
-When we talk about the speed of code reviews, it is the response time of a *single round* of review that we are concerned with, as opposed to how long it takes a PR to get through the whole review and be merged.
-The whole process should also be fast, ideally, but it's even more important for the *individual responses* to come quickly than it is for the whole process to happen rapidly.
-Developers typically don't mind going through multiple rounds of review if each round happens quickly.
-
-If you are too busy to do a full review on a PR when it comes in, you can still send a quick response that lets the developer know when you will get to it, suggest other reviewers who might be able to respond more quickly, or [provide some initial broad comments](#sec-broad) (none of this means you should interrupt coding even to send a response like this---send the response at a reasonable break point in your work).
+Most "deep work" sessions last around 2-3 hours, so batching your code reviews and handling multiple of them at once after a focused session often works well.
 
 ## Detailed review
 
-With all of this discussion about speed, it can be tempting to just do a surface level review and respond with "LGTM." **Resist this temptation**.
+With all of this discussion about speed, it can be tempting to just do a surface level review and respond with "LGTM." Resist this temptation!
 The whole [purpose of code review](#sec-purpose) is to ensure that the code health of the code base is improving, and you are unlikely to catch potential bugs with a surface level review.
 
-It is important to *start* a round of code review shortly after the PR is submitted, but PRs vary greatly in their complexity and sufficiently carrying out the review can sometimes take a decent amount of time.
+PRs vary greatly in their complexity and sufficiently carrying out the review can take a non-trivial amount of time and cognitive effort.
 In general:
 
 -   **Small PRs** take anywhere from **5-15 minutes** and don't typically require checking the code out locally.
@@ -65,39 +56,32 @@ In general:
 
 -   **Large PRs** can take up to **1 hour**, and occasionally even longer.
     These should be very rare, and are reserved for large refactorings, especially if there are unavoidable behavior changes mixed in.
-    Large PRs are typically undesirable because they slow the velocity of the entire team, so typically the reviewer should ask the developer if the PR can be [split into multiple smaller PRs](#sec-small).
+    Large PRs are typically undesirable because they slow the velocity of the entire team, so typically the reviewer should ask the author if the PR can be [split into multiple smaller PRs](#sec-small).
     If you don't have time to review a large PR and it can't be made any smaller, provide some broad comments on the design of the PR, and consider requesting another colleague to take a look.
 
-## Cross-time-zone reviews {#sec-cross-time-zone}
+## Cross time zone reviews {#sec-cross-time-zone}
 
-When dealing with time zone differences, try to get back to the author while they have time to respond before the end of their working hours.
-If they have already finished work for the day, then try to make sure your review is done before they start work the next day.
+Dealing with time zone differences can be challenging, but when the author and reviewer are [working together closely](#sec-close-knit-collaboration) it is reasonable for the reviewer to ensure that they provide feedback before the author starts work the next day.
+If more rapid turnaround times are needed, then the author should communicate that with the reviewer and attempt to batch multiple PRs in parallel, or set aside a predetermined time during the day when both the author and reviewer are online for review.
 
 ## Approve with comments {#sec-approve-with-comments}
 
-The most common kind of PR review at Posit is known as "approved with comments." It involves leaving a few minor comments on a PR, while also hitting the `Approve` button on the GitHub review UI:
+The most common kind of PR review within the tidyteam group is known as "approved with comments." It involves leaving a few minor comments on a PR, while also hitting the `Approve` button on the GitHub review UI:
 
 ![](img/approve-with-comments.png){fig-align="center" width="600"}
 
 This gives the PR author permission to merge the PR as soon as they have addressed the comments without needing to request another round of review.
 This is done when either:
 
--   The reviewer is confident that the developer will appropriately address all the reviewer's remaining comments.
--   The remaining changes are minor and don't *have* to be done by the developer.
+-   The reviewer is confident that the author will appropriately address all the reviewer's remaining comments.
+-   The remaining changes are minor and don't *have* to be done by the author.
 
 Approving with comments is largely about the experience of the PR author.
-For new developers that are still being onboarded, it is common to use the `Comment` option instead, which is a signal to the developer that they should request another round of review when they have finished addressing your comments.
+For new authors that are still being onboarded, it is common for reviewers to use the `Comment` option instead, which is a signal to the author that they should request another round of review when they have finished addressing your comments.
 It is important to remember to be patient with new developers; they are going to need multiple rounds of detailed reviews early on, but putting in this extra effort up front tends to lead to faster PRs in the future as the author learns more about what is expected from their PRs.
 
 ## Requesting changes {#sec-request-changes}
 
 GitHub also includes a third option when submitting a review, `Request changes`.
 This is typically reserved for more drastic changes that absolutely require another round of review.
-This option is rare to see in *internal PRs*, but is somewhat common with *external PRs* where the PR author is unlikely to be a core contributor on the project, and might not have the same expertise as another Posit employee.
-
-## Code review improvements over time {#sec-over-time}
-
-If you follow these guidelines and you are strict with your code reviews, you should find that the entire code review process tends to speed up over time.
-Developers learn what is required for healthy code, and send you PRs that are great from the start, requiring less and less review time.
-Reviewers learn to respond quickly and not add unnecessary latency into the review process.
-But **don't compromise on code quality for an imagined improvement in velocity**---it's not actually going to make anything happen more quickly, in the long run.
+This option is rare to see in [close-knit collaboration](#sec-close-knit-collaboration), when both the author and reviewer are experts, but is somewhat common when the author is an [understudy](#sec-the-understudy) and with [external contributions](#sec-external-contributions), where the author likely doesn't have as much expertise as the reviewer.


### PR DESCRIPTION
@lionel- I really liked your ideas! If you want to view locally, you can fork and `quarto::quarto_render()` and `quarto::quarto_preview()`.

TODO
- [x] Look for places where we use internal vs external and update as appropriate
- [x] Review `speed.qmd` and mention these patterns. Probably take out discussion of expected timings of how fast a review should be?